### PR TITLE
setting the tls flag correctly for openbsd and bitrig

### DIFF
--- a/configure
+++ b/configure
@@ -4886,6 +4886,7 @@ case "${host}" in
 	abi="elf"
 	$as_echo "#define JEMALLOC_PURGE_MADVISE_FREE  " >>confdefs.h
 
+	force_tls="0"
 	;;
   *-*-linux*)
 	CFLAGS="$CFLAGS"


### PR DESCRIPTION
this patch correctly disables thread local storage on OpenBSD and Bitrig.  @semarie this will make one of your port patches unnecessary.
