### PR TITLE
fixing the config flags for openbsd and bitrig

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,12 @@ case "${host}" in
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
 	force_lazy_lock="1"
 	;;
+  *-*-openbsd*|*-*-bitrig*)
+	CFLAGS="$CFLAGS"
+	abi="elf"
+	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
+	force_tls="0"
+	;;
   *-*-linux*)
 	CFLAGS="$CFLAGS"
 	CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"


### PR DESCRIPTION
This fixes the configure flags for OpenBSD and Bitrig.  This PR puts the change into the dev branch.
